### PR TITLE
Python: Closing resultFile correctly

### DIFF
--- a/Python/AbbyyOnlineSdk.py
+++ b/Python/AbbyyOnlineSdk.py
@@ -78,8 +78,9 @@ class AbbyyOnlineSdk:
 			return
 		request = urllib2.Request( getResultUrl )
 		fileResponse = self.getOpener().open( request ).read()
-		resultFile = open( outputPath, "wb" )
-		resultFile.write( fileResponse )
+		with open( outputPath, "wb" ) as resultFile:
+			resultFile.write( fileResponse )
+
 
 
 	def DecodeResponse( self, xmlResponse ):


### PR DESCRIPTION
The `resultFile` in the Python SDK was not closed correctly after writing to it. Files should always be closed when they are not used anymore to avoid corrupt file state and free up system resources. 
`With` closes the file properly even if an exception is raised.  