### PR TITLE
Fixed uncorrect fields naming (PagesCount->FilesCount)

### DIFF
--- a/WindowsPhone/Abbyy.CloudOcrSdk/RestServiceClient.cs
+++ b/WindowsPhone/Abbyy.CloudOcrSdk/RestServiceClient.cs
@@ -38,9 +38,9 @@ namespace Abbyy.CloudOcrSdk
         public DateTime StatusChangeTime;
 
         /// <summary>
-        /// Number of pages in task
+        /// Number of files in the task
         /// </summary>
-        public int PagesCount = 1;
+        public int FilesCount = 1;
 
         /// <summary>
         /// Task cost in credits

--- a/WindowsPhone/Abbyy.CloudOcrSdk/ServerXml.cs
+++ b/WindowsPhone/Abbyy.CloudOcrSdk/ServerXml.cs
@@ -85,12 +85,12 @@ namespace Abbyy.CloudOcrSdk
                     task.StatusChangeTime = time;
             }
 
-            XAttribute xPagesCount = xTask.Attribute("filesCount");
-            if (xPagesCount != null)
+            XAttribute xFilesCount = xTask.Attribute("filesCount");
+            if (xFilesCount != null)
             {
-                int pagesCount;
-                if (Int32.TryParse(xPagesCount.Value, out pagesCount))
-                    task.PagesCount = pagesCount;
+                int filesCount;
+                if (Int32.TryParse(xFilesCount.Value, out filesCount))
+                    task.FilesCount = filesCount;
             }
 
             XAttribute xCredits = xTask.Attribute("credits");

--- a/dotNet/General/GuiTest/Window1.xaml
+++ b/dotNet/General/GuiTest/Window1.xaml
@@ -245,8 +245,8 @@
                             
                             <GridViewColumn Width="100" Header="Created"
                                             DisplayMemberBinding="{Binding RegistrationTime}" />
-                            <GridViewColumn Width="100" Header="Pages"
-                                            DisplayMemberBinding="{Binding PagesCount}" />
+                            <GridViewColumn Width="100" Header="Files"
+                                            DisplayMemberBinding="{Binding FilesCount}" />
                             <GridViewColumn Width="100" Header="Description"
                                             DisplayMemberBinding="{Binding Description}" />
                             </GridView>

--- a/dotNet/General/GuiTest/Window1.xaml.cs
+++ b/dotNet/General/GuiTest/Window1.xaml.cs
@@ -546,7 +546,7 @@ namespace GuiTest
             SourceFilePath = null;
             TaskId = task.Id.ToString();
             TaskStatus = task.Status.ToString();
-            PagesCount = task.PagesCount;
+            FilesCount = task.FilesCount;
             Description = task.Description;
             RegistrationTime = task.RegistrationTime;
             StatusChangeTime = task.StatusChangeTime;
@@ -622,10 +622,10 @@ namespace GuiTest
             }
         }
 
-        public int PagesCount
+        public int FilesCount
         {
-            get { return _pagesCount; }
-            set { _pagesCount = value; NotifyPropertyChanged("PagesCount"); }
+            get { return _filesCount; }
+            set { _filesCount = value; NotifyPropertyChanged("FilesCount"); }
         }
 
         public string Description
@@ -694,7 +694,7 @@ namespace GuiTest
         private string _taskStatus;
         private string _outputFilePath;
 
-        private int _pagesCount;
+        private int _filesCount;
         private string _description;
 
 

--- a/dotNet/General/dotNetWrapper/RestServiceClient.cs
+++ b/dotNet/General/dotNetWrapper/RestServiceClient.cs
@@ -34,9 +34,9 @@ namespace Abbyy.CloudOcrSdk
         public DateTime StatusChangeTime;
 
         /// <summary>
-        /// Number of pages in task
+        /// Number of files in the task
         /// </summary>
-        public int PagesCount = 1;
+        public int FilesCount = 1;
 
         /// <summary>
         /// Task cost in credits

--- a/dotNet/General/dotNetWrapper/ServerXml.cs
+++ b/dotNet/General/dotNetWrapper/ServerXml.cs
@@ -85,12 +85,12 @@ namespace Abbyy.CloudOcrSdk
                     task.StatusChangeTime = time;
             }
 
-            XAttribute xPagesCount = xTask.Attribute("filesCount");
-            if (xPagesCount != null)
+            XAttribute xFilesCount = xTask.Attribute("filesCount");
+            if (xFilesCount != null)
             {
-                int pagesCount;
-                if (Int32.TryParse(xPagesCount.Value, out pagesCount))
-                    task.PagesCount = pagesCount;
+                int filesCount;
+                if (Int32.TryParse(xFilesCount.Value, out filesCount))
+                    task.FilesCount = filesCount;
             }
 
             XAttribute xCredits = xTask.Attribute("credits");

--- a/dotNet/Receipt/Tools/RestServiceClient.cs
+++ b/dotNet/Receipt/Tools/RestServiceClient.cs
@@ -34,9 +34,9 @@ namespace Sample
         public DateTime StatusChangeTime;
 
         /// <summary>
-        /// Number of pages in task
+        /// Number of files in the task
         /// </summary>
-        public int PagesCount = 1;
+        public int FilesCount = 1;
 
         /// <summary>
         /// Task cost in credits

--- a/dotNet/Receipt/Tools/ServerXml.cs
+++ b/dotNet/Receipt/Tools/ServerXml.cs
@@ -85,12 +85,12 @@ namespace Sample
                     task.StatusChangeTime = time;
             }
 
-            XAttribute xPagesCount = xTask.Attribute("filesCount");
-            if (xPagesCount != null)
+            XAttribute xFilesCount = xTask.Attribute("filesCount");
+            if (xFilesCount != null)
             {
-                int pagesCount;
-                if (Int32.TryParse(xPagesCount.Value, out pagesCount))
-                    task.PagesCount = pagesCount;
+                int filesCount;
+                if (Int32.TryParse(xFilesCount.Value, out filesCount))
+                    task.FilesCount = filesCount;
             }
 
             XAttribute xCredits = xTask.Attribute("credits");


### PR DESCRIPTION
Fixed incorrect fields naming (PagesCount->FilesCount) in .Net examples: 

- dotNet\Receipt

- dotNet\General

- WindowsPhone
